### PR TITLE
Collapsible detail tag formats incorrectly.

### DIFF
--- a/Ao3-Previewer/frontend/src/utilities/formatForAo3.ts
+++ b/Ao3-Previewer/frontend/src/utilities/formatForAo3.ts
@@ -25,7 +25,7 @@ export function formatForAo3(html: string): string {
 
       function flushGroup() {
         if (inlineGroup.length === 0) return
-        if (node.tagName?.toLowerCase() === 'p') {
+        if (node.tagName?.toLowerCase() === 'p' || node.tagName?.toLowerCase() === 'summary') {
           inlineGroup = []
           return
         }

--- a/Ao3-Previewer/frontend/src/utilities/normalizeForAo3.ts
+++ b/Ao3-Previewer/frontend/src/utilities/normalizeForAo3.ts
@@ -22,7 +22,7 @@ export function normalizeForAo3(html: string): string {
 
       function flushGroup() {
         if (inlineGroup.length === 0) return
-        if (node.tagName?.toLowerCase() === 'p') {
+        if (node.tagName?.toLowerCase() === 'p' || node.tagName?.toLowerCase() === 'summary') {
           inlineGroup = []
           return
         }


### PR DESCRIPTION
Fixed issue where normalization incorrectly identified summary tags as processnodes instead of inline group.